### PR TITLE
Fix Redis default config

### DIFF
--- a/lib/generators/aeternitas/templates/initializer.rb
+++ b/lib/generators/aeternitas/templates/initializer.rb
@@ -1,6 +1,6 @@
 # Configure Aeternitas
 Aeternitas.configure do |config|
-  config.redis = { url: 'localhost', port: 6379 } #this is the default Redis config which should work in most cases.
+  config.redis = { host: 'localhost', port: 6379 } #this is the default Redis config which should work in most cases.
 end
 
 Sidekiq.configure_server do |config|


### PR DESCRIPTION
- use host parameter instead of url
- redis url parameter expects schema (e.g. redis://localhost)